### PR TITLE
Fix path handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 import argparse
+import os
 from prediction.prediction import run_predictions
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Ca Backbone Prediction from High Resolution CryoEM Data')
-    parser.add_argument('input', type=str, help='Folder containing protein maps')
-    parser.add_argument('output', type=str, help='Folder where prediction results will be stored')
+    parser.add_argument('input', type=os.path.abspath, help='Folder containing protein maps')
+    parser.add_argument('output', type=os.path.abspath, help='Folder where prediction results will be stored')
     parser.add_argument('-t', '--thresholds', metavar='Thresholds', type=str,
                         help='JSON file which contains the thresholds')
     parser.add_argument('-s', '--skip', metavar='N', type=int, nargs=1, default=[0],

--- a/prediction/prediction.py
+++ b/prediction/prediction.py
@@ -60,8 +60,15 @@ def run_predictions(input_path, output_path, thresholds_file, num_skip, check_ex
     start_time = time()
     max_processes_allowed_to_access_tensorflow = 4
     semaphore = Semaphore(min(min(cpu_count(), len(params_list)), max_processes_allowed_to_access_tensorflow))
+
     pool = Pool(min(cpu_count(), len(params_list)), initializer=init_child, initargs=(semaphore,))
     results = pool.map(run_prediction, params_list)
+
+    # for single-process debugging
+    # init_child(semaphore)
+    # results = []
+    # for params in params_list:
+    #     results.append(run_prediction(params))
 
     # Filter 'None' results
     results = filter(lambda r: r is not None, results)

--- a/preprocessing/clean_map.py
+++ b/preprocessing/clean_map.py
@@ -30,7 +30,7 @@ def execute(paths):
         prediction
     """
 
-    copyfile(os.getcwd() + '/Ca-Backbone-Prediction/preprocessing/bounding_box.ent', paths['bounding_box'])
+    copyfile(os.path.dirname(__file__) + '/bounding_box.ent', paths['bounding_box'])
 
     chimera_script = open(paths['output'] + 'resample.cmd', 'w')
 
@@ -60,21 +60,21 @@ def execute(paths):
         chimera_script.write('open ' + paths['input'] + '\n'
                          'cofr models\n'
                          'cofr fixed\n'
-                         'open ' + paths['bounding_box'] + '\n'                         
+                         'open ' + paths['bounding_box'] + '\n'
                          'move cofr mod #1\n'
                          'write relative #0 #1 ' + paths['bounding_box_centered'] + '\n'
                          'open ' + paths['bounding_box_centered'] + '\n'
-                         'molmap #2 6 gridSpacing 1\n'                        
+                         'molmap #2 6 gridSpacing 1\n'
                          'sel #0\n'
                          'vop resample sel onGrid #2.1\n'
                          'volume #3 save ' + paths['cleaned_map'])
-                     
+
     chimera_script.close()
 
     script_finished = False
     while not script_finished:
         try:
-            subprocess.run(['/usr/local/bin/chimera', '--nogui', chimera_script.name])
+            subprocess.run(['chimera', '--nogui', chimera_script.name])
             script_finished = True
         except FileNotFoundError as error:
             if not create_symbolic_link():

--- a/preprocessing/find_threshold.py
+++ b/preprocessing/find_threshold.py
@@ -93,7 +93,7 @@ def sav(threshold, paths):
                          'measure area #0\n')
     chimera_script.close()
 
-    output = subprocess.check_output(['/usr/local/bin/chimera', '--nogui', chimera_script.name])
+    output = subprocess.check_output(['chimera', '--nogui', chimera_script.name])
     volume, surface_area = parse_sav(output)
 
     os.remove(chimera_script.name)

--- a/preprocessing/find_threshold.py
+++ b/preprocessing/find_threshold.py
@@ -25,7 +25,8 @@ __author__ = 'Jonas Pfab'
 
 
 def update_paths(paths):
-    paths['threshold'] = paths['output'] + 'threshold'
+    if not is_threshold_provided(paths):
+        paths['threshold'] = paths['output'] + 'threshold'
 
 
 def execute(paths):


### PR DESCRIPTION
This fixes up some of the path handling to be more robust to different environments / usage.

- Uses absolute paths for `input` and `output` so that the generated chimera files work regardless of cwd
- Uses the environment chimera instead of looking in a specific path
- Fixes the 'threshold' path so that --check-existing works even if --thresholds-file is provided